### PR TITLE
VC 2010 Compile Issues

### DIFF
--- a/ext/ruby_debug/extconf.rb
+++ b/ext/ruby_debug/extconf.rb
@@ -3,7 +3,7 @@ require "ruby_core_source"
 
 hdrs = proc {
   have_struct_member("rb_method_entry_t", "body", "method.h")
-  have_header("vm_core.h") and have_header("iseq.h") and have_header("insns.inc") and 
+  have_header("vm_core.h") and have_header("iseq.h", "vm_core.h") and have_header("insns.inc") and
   have_header("insns_info.inc") and have_header("eval_intern.h")
 }
 


### PR DESCRIPTION
These changes allow VC++ to compile ruby-debug-bas19x.

Changes are:
- In extconf.rb,  iseq.h requires vm_core.h to compile.  Not sure why this doesn't blow up other compilers
- The declarations for rb_vm_get_sourceline and rb_iseq_compile_with_option do not match the ones in vm_core.h. They include an extra RUBY_EXTERN and therefore are not correct (note for VC RUBY_EXTERN is defined as declspec(dllimport) when compiling against a dll.
- The remaining changes are due to VC++ requiring variable to be defined at the start of blocks when compiling c code.

Note this fixes the compilation issues, but there is still a linker issue that is due to Ruby.  See http://redmine.ruby-lang.org/issues/5193

Thanks - Charlie
