### PR TITLE
Ruby 193 Support

### DIFF
--- a/ext/ruby_debug/extconf.rb
+++ b/ext/ruby_debug/extconf.rb
@@ -2,18 +2,26 @@ require "mkmf"
 require "ruby_core_source"
 
 hdrs = proc {
-  have_struct_member("rb_method_entry_t", "body", "method.h")
+  iseqs = %w[vm_core.h iseq.h]
+  begin
+    have_struct_member("rb_method_entry_t", "called_id", "method.h") or
+    have_struct_member("rb_control_frame_t", "method_id", "method.h")
+  end and
   have_header("vm_core.h") and have_header("iseq.h", "vm_core.h") and have_header("insns.inc") and
-  have_header("insns_info.inc") and have_header("eval_intern.h")
+  have_header("insns_info.inc") and have_header("eval_intern.h") or break
+  have_type("struct iseq_line_info_entry", iseqs) or
+  have_type("struct iseq_insn_info_entry", iseqs) or
+  break
+  if checking_for(checking_message("if rb_iseq_compile_with_option was added an argument filepath")) do
+      try_compile(<<SRC)
+#include <ruby.h>
+#include "vm_core.h"
+extern VALUE rb_iseq_new_main(NODE *node, VALUE filename, VALUE filepath);
+SRC
+    end
+    $defs << '-DRB_ISEQ_COMPILE_5ARGS'
+  end
 }
-
-if RUBY_VERSION == '1.9.1'
-  $CFLAGS << ' -DRUBY_VERSION_1_9_1'
-end
-
-if RUBY_REVISION >= 26959 # rb_iseq_compile_with_option was added an argument filepath  
-  $CFLAGS << ' -DRB_ISEQ_COMPILE_6ARGS'
-end
 
 dir_config("ruby")
 name = "ruby_debug"


### PR DESCRIPTION
Fixes to make ruby-debug-base19x work on Ruby 1.9.3.  These patches are manually applied from this pull request:

https://github.com/mark-moseley/ruby-debug/pull/14

Minus the id2ref and ref2id changes (not sure if those can be removed or not).
