### PR TITLE
Compile with MSVC

### DIFF
--- a/ext/ruby_debug/ruby_debug.c
+++ b/ext/ruby_debug/ruby_debug.c
@@ -521,9 +521,9 @@ filename_cmp_impl(VALUE source, char *file);
 
 int
 filename_cmp(VALUE source, char *file) {
-#ifdef __WIN32__
+#ifdef _WIN32
     return filename_cmp_impl(source, file);
-#endif
+#else
 
     if (!RTEST(resolve_symlinks)) {
         return filename_cmp_impl(source, file);
@@ -546,6 +546,7 @@ filename_cmp(VALUE source, char *file) {
       free(path);
       return result;
     }
+#endif  
 #endif  
 }
 


### PR DESCRIPTION
Fixes to compile with MSVC.  Also, the **WIN32** check was incorrect, also affecting mingw.
